### PR TITLE
Fix Facebook secret key name to be consistent

### DIFF
--- a/src/CriThink.Server/CriThink.Server.Web/Providers/ExternalLogin/FacebookProvider.cs
+++ b/src/CriThink.Server/CriThink.Server.Web/Providers/ExternalLogin/FacebookProvider.cs
@@ -22,7 +22,7 @@ namespace CriThink.Server.Web.Providers.ExternalLogin
 
         public async Task<ExternalProviderUserInfo> GetUserAccessInfo(string userToken)
         {
-            var accessToken = _configuration["FacebookAPIKey"];
+            var accessToken = _configuration["FacebookApiKey"];
 
             var tokenInfoPath = $"debug_token?input_token={userToken}&access_token={accessToken}";
             


### PR DESCRIPTION
**Note:** Remember to update your `secrets.json` file. Replace the key name `FacebookAPIKey` with `FacebookApiKey`. (take the value from Facebook Developer Console)